### PR TITLE
Fix in body parameters format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_store
+.npmrc

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## apidoc-swagger-3.0
+## apidoc-openapi-3.0
 
 Apidoc and swagger are two nice projects which are focusing on documentation of APIs. 
 This project is a middle tier which tries to bring them together in a sense that:
@@ -7,21 +7,14 @@ This project is a middle tier which tries to bring them together in a sense that
 Uses the [apidoc-core](https://github.com/apidoc/apidoc-core) library.
 
 ## Why use it
-Inspired by [apidoc-swagger](https://github.com/fsbahman/apidoc-swagger)  
+Inspired by [apidoc-swagger](https://github.com/fsbahman/apidoc-swagger-3)  
 
-The old repo may not be maintained, and not support new api-doc feature,  
-such as
-
-- **distinguish Query or Body in Post request**  
-- **@apiHeader**
-- **old repo not suppport multi input dirs**
+The old repo may not be maintained, and not support new api-doc feature
 
 and this repo add new feature  
 
-- **support convert apidoc example to swagger schema**
-- **merge apidoc schema based on schema(converted by example)**
-- **support auto replace mark liking {{your_tag}} with data in js/ts/json files**
-- swagger.json version 3.0
+- **support convert body parameters schema for openapi 3.0.0 **
+- **support convert header/query parameters schema for openapi 3.0.0 **
 
 
 ## How It Works
@@ -68,8 +61,4 @@ By putting in line comments in the source code like this in javascript, you will
 it will output json [swagger.json](./doc/swagger.json)
 
 ## Tips
-you should always use command <pre>apidoc-swagger-3</pre> directly, if you use <pre>npx apidoc-swagger-3</pre>, this lib is not able to find hook, replacing mark would be failed
-
-
-## Source
-* [apiHooksExample](https://github.com/apidoc/apidoc-plugin-test)
+you should always use command <pre>apidoc-openapi-3</pre> directly, if you use <pre>npx apidoc-swagger-3</pre>, this lib is not able to find hook, replacing mark would be failed

--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ By putting in line comments in the source code like this in javascript, you will
 it will output json [swagger.json](./doc/swagger.json)
 
 ## Tips
-you should always use command <pre>apidoc-openapi-3</pre> directly, if you use <pre>npx apidoc-swagger-3</pre>, this lib is not able to find hook, replacing mark would be failed
+you should always use command <pre>apidoc-openapi-3</pre> directly, if you use <pre>npx apidoc-openapi-3</pre>, this lib is not able to find hook, replacing mark would be failed

--- a/apidoc_to_swagger.js
+++ b/apidoc_to_swagger.js
@@ -71,23 +71,27 @@ function extractPaths(apidocJson) {  // cf. https://swagger.io/specification/#pa
 
 function mapHeaderItem(i) {
     return {
-        type: 'string',
         in: 'header',
         name: i.field,
         description: removeTags(i.description),
         required: !i.optional,
-        default: i.defaultValue
+        schema: {
+            type: 'string',
+            default: i.defaultValue
+        }
     }
 }
 
 function mapQueryItem(i) {
     return {
-        type: 'string',
         in: 'query',
         name: i.field,
         description: removeTags(i.description),
         required: !i.optional,
-        default: i.defaultValue
+        schema: {
+            type: 'string',
+            default: i.defaultValue
+        }
     }
 }
 

--- a/apidoc_to_swagger.js
+++ b/apidoc_to_swagger.js
@@ -167,6 +167,7 @@ function transferApidocParamsToSwaggerBody(apiDocParams, parameterInBody) {
 function generateProps(verb) {
     const pathItemObject = {}
     const parameters = generateParameters(verb)
+    const body = generateBody(verb)
     const responses = generateResponses(verb)
     pathItemObject[verb.type] = {
         tags: [verb.group],
@@ -179,10 +180,37 @@ function generateProps(verb) {
             "application/json"
         ],
         parameters,
+        requestBody: {
+            content: {
+                'application/json': body
+            }
+        },
         responses
     }
 
     return pathItemObject
+}
+
+function generateBody(verb) {
+    const mixedBody = []
+
+    if (verb && verb.parameter && verb.parameter.fields) {
+        const Parameter = verb.parameter.fields.Parameter || []
+        const _body = verb.parameter.fields.Body || []
+        mixedBody.push(..._body)
+        if (verb.type === 'get') {
+
+        } else {
+            mixedBody.push(...Parameter)
+        }
+    }
+
+    let body = {}
+    if (verb.type === 'post' || verb.type === 'put') {
+        body = generateRequestBody(verb, mixedBody)
+    }
+
+    return body
 }
 
 function generateParameters(verb) {
@@ -206,9 +234,9 @@ function generateParameters(verb) {
     const parameters = []
     parameters.push(...mixedQuery.map(mapQueryItem))
     parameters.push(...header.map(mapHeaderItem))
-    if (verb.type === 'post' || verb.type === 'put') {
+    /*if (verb.type === 'post' || verb.type === 'put') {
         parameters.push(generateRequestBody(verb, mixedBody))
-    }
+    }*/
     parameters.push(...(verb.query || []).map(mapQueryItem))
 
     return parameters
@@ -216,7 +244,7 @@ function generateParameters(verb) {
 
 function generateRequestBody(verb, mixedBody) {
     const bodyParameter = {
-        in: 'body',
+       // in: 'body',
         schema: {
             properties: {},
             type: 'object',

--- a/apidoc_to_swagger.js
+++ b/apidoc_to_swagger.js
@@ -234,9 +234,6 @@ function generateParameters(verb) {
     const parameters = []
     parameters.push(...mixedQuery.map(mapQueryItem))
     parameters.push(...header.map(mapHeaderItem))
-    /*if (verb.type === 'post' || verb.type === 'put') {
-        parameters.push(generateRequestBody(verb, mixedBody))
-    }*/
     parameters.push(...(verb.query || []).map(mapQueryItem))
 
     return parameters
@@ -244,7 +241,6 @@ function generateParameters(verb) {
 
 function generateRequestBody(verb, mixedBody) {
     const bodyParameter = {
-       // in: 'body',
         schema: {
             properties: {},
             type: 'object',

--- a/apidoc_to_swagger.js
+++ b/apidoc_to_swagger.js
@@ -198,9 +198,7 @@ function generateBody(verb) {
         const Parameter = verb.parameter.fields.Parameter || []
         const _body = verb.parameter.fields.Body || []
         mixedBody.push(..._body)
-        if (verb.type === 'get') {
-
-        } else {
+        if (!(verb.type === 'get'))  {
             mixedBody.push(...Parameter)
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@tgeant/apidoc-openapi-3",
+    "name": "apidoc-openapi-3",
     "version": "1.0.0",
     "description": "Convert api doc json to openapi 3 json",
     "author": "tancrede GEANT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "apidoc-openapi-3",
+    "name": "@tgeant/apidoc-openapi-3",
     "version": "1.0.0",
     "description": "Convert api doc json to openapi 3 json",
     "author": "tancrede GEANT",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "apidoc-swagger-3",
-    "version": "1.0.5",
-    "description": "Convert api doc json to swagger3 json",
-    "author": "amano hikaru",
+    "name": "apidoc-openapi-3",
+    "version": "1.0.0",
+    "description": "Convert api doc json to openapi 3 json",
+    "author": "tancrede GEANT",
     "main": "bin.js",
     "bin": "bin.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/amanoooo/apidoc-swagger-3"
+        "url": "https://github.com/tgeant/apidoc-swagger-3"
     },
     "bugs": {
-        "url": "https://github.com/amanoooo/apidoc-swagger-3/issues"
+        "url": "https://github.com/tgeant/apidoc-swagger-3/issues"
     },
     "keywords": [
         "api",
@@ -18,7 +18,8 @@
         "doc",
         "documentation",
         "swagger",
-        "swagger-3.0"
+        "swagger-3.0",
+        "openapi"
     ],
     "scripts": {
         "test": "jest"


### PR DESCRIPTION
Hello,

The current swagger format generated by this project was not fully recognize when imported to postman. The requestBody was missing, because the schema didn't match the recommended format for the body: https://swagger.io/docs/specification/describing-request-body/

This PR fix it.

Note: Only compatible for 'application/json' body format.